### PR TITLE
Add better API key handling

### DIFF
--- a/nhl-graphql-api/api/graphql.js
+++ b/nhl-graphql-api/api/graphql.js
@@ -25,7 +25,7 @@ module.exports = startServerAndCreateNextHandler(server, {
         try {
             // Log request information
             console.log(`[${new Date().toISOString()}] Incoming request to Vercel function`);
-            
+
             // Special handling for GraphQL playground and introspection
             const isIntrospection = req.body?.operationName === 'IntrospectionQuery' ||
                 req.body?.query?.includes('__schema');
@@ -42,14 +42,7 @@ module.exports = startServerAndCreateNextHandler(server, {
 
             // Handle no API key case
             if (!apiKey) {
-                // Handle public access (if enabled)
-                if (process.env.ALLOW_PUBLIC_ACCESS === 'true') {
-                    console.log('Public access allowed');
-                    return { customer: { name: 'Public', plan: 'free' } };
-                }
-
                 return { error: 'API key is required' };
-                //throw new Error('API key is required');
             }
 
             // Get customer details

--- a/nhl-graphql-api/api/graphql.js
+++ b/nhl-graphql-api/api/graphql.js
@@ -42,7 +42,7 @@ module.exports = startServerAndCreateNextHandler(server, {
 
             // Handle no API key case
             if (!apiKey) {
-                return { error: 'API key is required' };
+                throw new Error('API key is required');
             }
 
             // Get customer details
@@ -50,8 +50,7 @@ module.exports = startServerAndCreateNextHandler(server, {
             console.log('Customer validation:', customer ? 'Valid' : 'Invalid');
 
             if (!customer) {
-                return { error: `Invalid API key: ${apiKey.substring(0, 6)}...` };
-                //throw new Error('Invalid API key', apiKey.substring(0, 6));
+                throw new Error('Invalid API key', apiKey.substring(0, 6));
             }
 
             console.log(`Authenticated user: ${customer.name}, Plan: ${customer.plan}`);


### PR DESCRIPTION
This pull request simplifies the error handling logic in the `nhl-graphql-api/api/graphql.js` file. The main change involves replacing conditional logic for handling missing or invalid API keys with direct error throwing, ensuring a more consistent and streamlined approach.

Error handling improvements:

* Removed support for public access when no API key is provided, and replaced it with an error throw (`throw new Error('API key is required')`). This simplifies the logic and enforces stricter API key requirements.
* Replaced the return of an error object for invalid API keys with an error throw (`throw new Error('Invalid API key', apiKey.substring(0, 6))`). This ensures invalid API key handling is more robust and aligns with standard error handling practices.